### PR TITLE
[documentation]: fixed broken links in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 ## Getting started
 
-A getting started guide and some other information related to integrating and setting up the SDK can be found in the [wiki](https://bitbucket.org/mobgen/halo-sdk-ios/wiki/Home).
+A getting started guide and some other information related to integrating and setting up the SDK can be found in the [wiki](https://mobgen.github.io/halo-documentation/ios_getting_started.html).
 
 ## API documentation
 
-The latest API documentation (Swift oriented) can be checked [here](http://borjasantos.bitbucket.org/docs/ios/halo-sdk/).
+The latest API documentation (Swift oriented) can be checked [here](https://mobgen.github.io/halo-documentation/ios_home.html).
 
 ## Contribute
 


### PR DESCRIPTION
I have fixed some broken links in README file due to the migration from Bitbucket to GitHub.